### PR TITLE
Fix 2 dash hair color

### DIFF
--- a/Graphics/Atlases/Gameplay/characters/Gosha/Lea/skinConfig/HairConfig.yaml
+++ b/Graphics/Atlases/Gameplay/characters/Gosha/Lea/skinConfig/HairConfig.yaml
@@ -15,7 +15,7 @@ HairColors:
   - Dashes: 1
     Color: "1144AA"
   - Dashes: 2
-    Color: "FF7BFF"
+    Color: "222244"
 
 HairFlash: true # Enables the distracting white flash that happens when your dash count changes.
 OutlineColor: "040000" # This specifies the hair outline color, not the sprite outline.

--- a/Graphics/Atlases/Gameplay/characters/Gosha/Lea_playback/skinConfig/HairConfig.yaml
+++ b/Graphics/Atlases/Gameplay/characters/Gosha/Lea_playback/skinConfig/HairConfig.yaml
@@ -15,7 +15,7 @@ HairColors:
   - Dashes: 1
     Color: "1144AA"
   - Dashes: 2
-    Color: "FF7BFF"
+    Color: "222244"
 
 HairFlash: true # Enables the distracting white flash that happens when your dash count changes.
 OutlineColor: "040000" # This specifies the hair outline color, not the sprite outline.


### PR DESCRIPTION
This PR replaces the default pink color with black to better match the sprites

To my knowledge, this affects:
- Player dying / respawning particles
- The Extended Variants Mod option "Madeline is a Silhouette"
- Madeline's hair color as seen by other players with CelesteNet while the CeLeaste mod isn't installed

Before:

https://github.com/user-attachments/assets/909f80af-334c-4471-8dc0-41898fddbbfe

After:

https://github.com/user-attachments/assets/df41f69d-9ebb-4a97-950f-147281da2751

If there's a reason this wasn't done earlier, feel free to let me know and close this PR.

While I'm here, thank you so much for creating such an amazing mod! I love the animation work that went into this, it feels really polished and great to play.